### PR TITLE
Prefixed manual symlink with sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Clone `cfengine/core` repo where you want, and then symlink, like this:
 
 ```
 $ git clone https://github.com/cfengine/cf-remote.git
-$ ln -s `pwd`/cf-remote/cf_remote/__main__.py /usr/local/bin/cf-remote
+$ sudo ln -s `pwd`/cf-remote/cf_remote/__main__.py /usr/local/bin/cf-remote
 ```
 
 Install dependencies:


### PR DESCRIPTION
`/usr/local/bin` usually requires elevated privileges to modify.

```
> $ ls -al /usr/local/bin/. | head -n 2
total 44812
drwxr-xr-x  3 root root     4096 Jan 26 13:47 .
```