### PR TITLE
Made deploy command more friendly and accept tarballs, URLs, relative paths, etc.

### DIFF
--- a/cf_remote/commands.py
+++ b/cf_remote/commands.py
@@ -513,14 +513,22 @@ def deploy(hubs, masterfiles):
     if not directory.endswith("/masterfiles"):
         log.error("The masterfiles directory to deploy must be called 'masterfiles'")
         return 1
-    if not os.path.isfile(directory + "/autogen.sh"):
-        log.error(f"'{directory}' must be a source checkout and contain the autogen.sh script")
-        return 1
 
-    os.system(f"bash -c 'cd {directory} && ./autogen.sh 1>/dev/null 2>&1'")
-    if not os.path.isfile(directory + "/promises.cf"):
-        log.error(f"The autogen.sh script did not produce promises.cf in '{directory}'")
-        return 1
+    if os.path.isfile(f"{directory}/autogen.sh"):
+        os.system(f"bash -c 'cd {directory} && ./autogen.sh 1>/dev/null 2>&1'")
+        if not os.path.isfile(f"{directory}/promises.cf"):
+            log.error(f"The autogen.sh script did not produce promises.cf in '{directory}'")
+            return 1
+    elif os.path.isfile(f"{directory}/configure"):
+        os.system(f"bash -c 'cd {directory} && ./configure 1>/dev/null 2>&1'")
+        if not os.path.isfile(f"{directory}/promises.cf"):
+            log.error(f"The configure script did not produce promises.cf in '{directory}'")
+            return 1
+    else:
+        log.debug("No autogen.sh / configure found, assuming ready to install directory")
+        if not os.path.isfile(f"{directory}/promises.cf"):
+            log.error(f"No promises.cf in '{directory}'")
+            return 1
 
     assert(not cf_remote_dir().endswith("/"))
     tarball = cf_remote_dir() + "/masterfiles.tgz"

--- a/cf_remote/commands.py
+++ b/cf_remote/commands.py
@@ -478,8 +478,8 @@ def uninstall(hosts):
 def deploy_tarball(hubs, tarball):
     assert os.path.isfile(tarball)
 
-    if not tarball.endswith("/masterfiles.tgz"):
-        log.error("The masterfiles tarball to deploy must be called 'masterfiles.tgz'")
+    if not tarball.endswith((".tgz", ".tar.gz")):
+        log.error("The masterfiles directory must be in a gzipped tarball (.tgz or .tar.gz)")
         return 1
 
     errors = 0
@@ -488,8 +488,16 @@ def deploy_tarball(hubs, tarball):
     return errors
 
 def deploy(hubs, masterfiles):
-    masterfiles = os.path.abspath(os.path.expanduser(masterfiles))
-    log.debug(f"Deploy path expanded to: {masterfiles}")
+    if masterfiles.startswith(("http://", "https://")):
+        urls = [masterfiles]
+        paths = _download_urls(urls)
+        assert len(paths) == 1
+        masterfiles = paths[0]
+        log.debug(f"Deploying downloaded: {masterfiles}")
+    else:
+        masterfiles = os.path.abspath(os.path.expanduser(masterfiles))
+        log.debug(f"Deploy path expanded to: {masterfiles}")
+
     if masterfiles.endswith("/"):
         masterfiles = masterfiles[0:-1]
 

--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -252,7 +252,10 @@ def validate_command(command, args):
             user_error("Must specify a path to masterfiles")
         if not args.hub:
             user_error("Must specify at least one hub")
-        if not os.path.exists(args.masterfiles):
+        if args.masterfiles.startswith(("http://", "https://")):
+            if not args.masterfiles.endswith((".tgz", ".tar.gz")):
+                user_error("masterfiles URL must be to a gzipped tarball (.tgz or .tar.gz)")
+        elif not os.path.exists(args.masterfiles):
             user_error(f"'{args.masterfiles}' does not exist")
 
 

--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -109,9 +109,9 @@ def get_args():
     dp.add_argument("--all", help="Destroy all hosts spawned in the clouds", action='store_true')
     dp.add_argument("name", help="Name fo the group of hosts to destroy", nargs='?')
 
-    sp = subp.add_parser("deploy", help="Deploy masterfiles directory to hub")
+    sp = subp.add_parser("deploy", help="Deploy masterfiles to hub")
     sp.add_argument("--hub", help="Hub(s) to deploy to", type=str, required=True)
-    sp.add_argument("directory", help="Path to local masterfiles directory", type=str)
+    sp.add_argument("masterfiles", help="Path to local masterfiles directory or tarball", type=str)
 
     args = ap.parse_args()
     return args
@@ -186,7 +186,7 @@ def run_command_with_args(command, args):
         group_name = args.name if args.name else None
         return commands.destroy(group_name)
     elif command == "deploy":
-        return commands.deploy(args.hub, args.directory)
+        return commands.deploy(args.hub, args.masterfiles)
     else:
         user_error("Unknown command: '{}'".format(command))
 
@@ -248,12 +248,12 @@ def validate_command(command, args):
             user_error("One of --all or NAME required for destroy")
 
     if command == "deploy":
-        if not args.directory:
-            user_error("Must specify a masterfiles directory")
+        if not args.masterfiles:
+            user_error("Must specify a path to masterfiles")
         if not args.hub:
             user_error("Must specify at least one hub")
-        if not os.path.isdir(args.directory):
-            user_error(f"'{args.directory}' is not a directory")
+        if not os.path.exists(args.masterfiles):
+            user_error(f"'{args.masterfiles}' does not exist")
 
 
 def is_in_cloud_state(name):

--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -387,7 +387,7 @@ def deploy_masterfiles(host, tarball, *, connection=None):
         log.error(f"Cannot deploy masterfiles on {host} - CFEngine not installed")
         return 1
     
-    scp(tarball, host, connection=connection)
+    scp(tarball, host, connection=connection, rename="masterfiles.tgz")
     ssh_cmd(connection, f"tar -xzf masterfiles.tgz")
     commands = [
         "systemctl stop cfengine3",

--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -381,6 +381,7 @@ def uninstall_host(host, *, connection=None):
 @auto_connect
 def deploy_masterfiles(host, tarball, *, connection=None):
     data = get_info(host, connection=connection)
+    print("\nDeploying to:")
     print_info(data)
     if not data["agent_version"]:
         log.error(f"Cannot deploy masterfiles on {host} - CFEngine not installed")

--- a/cf_remote/ssh.py
+++ b/cf_remote/ssh.py
@@ -57,13 +57,17 @@ def auto_connect(func):
     return connect_wrapper
 
 
-def scp(file, remote, connection=None):
+def scp(file, remote, connection=None, rename=None):
     if not connection:
         with connect(remote) as connection:
-            scp(file, remote, connection)
+            scp(file, remote, connection, rename)
     else:
         print("Copying: '{}' to '{}'".format(file, remote))
         connection.put(file)
+        if rename:
+            file = os.path.basename(file)
+            print(f"Renaming '{file}' -> '{rename}' on '{remote}'")
+            ssh_cmd(connection, f"mv {file} {rename}")
     return 0
 
 

--- a/cf_remote/utils.py
+++ b/cf_remote/utils.py
@@ -76,7 +76,7 @@ def above_package_path():
 
 
 def is_package_url(string):
-    return bool(re.match("https?://.+/.+\.(rpm|deb|msi)", string))
+    return bool(re.match("https?://.+/.+\.(rpm|deb|msi|tar\.gz|tgz)", string))
 
 
 def get_package_name(url):


### PR DESCRIPTION
Enabled a few different ways to use this command.

Inside masterfiles folder:

```
cf-remote deploy --hub hub .
```

Relative path with trailing slash:

```
cf-remote deploy --hub hub ../masterfiles/
```

Tarball directly, without running autotools and tar:

```
cf-remote deploy --hub hub /home/olehermanse/.cfengine/cf-remote/masterfiles.tgz
```

Gzipped tarball from URL:

```
cf-remote deploy --hub hub https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.15.3/misc/cfengine-masterfiles-3.15.3-1.pkg.tar.gz
```

Installed masterfiles folder, without autogen or configure:

```
cf-remote deploy --hub hub /var/cfengine/masterfiles
```