### PR TITLE
Fix GitHub Action event trigger for releases

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:


### PR DESCRIPTION
Previously, creating a draft release and publishing it, would not trigger this action.

Docs are a little hard to decipher, but it seems to me that what we want is "published":

https://docs.github.com/en/rest/reference/repos#releases