### PR TITLE
CFE-3792: Changed python version requirement from >=3.6 to >=3.5

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/cf_remote/commands.py
+++ b/cf_remote/commands.py
@@ -96,7 +96,7 @@ def _download_urls(urls):
         paths.append(path)
 
         if path in downloaded_paths and url not in downloaded_urls:
-            user_error(f"2 packages with the same name '{name}' from different URLs")
+            user_error("2 packages with the same name '%s' from different URLs" % name)
 
         download_package(url, path)
         downloaded_urls.append(url)
@@ -198,7 +198,7 @@ def install(
 
     if errors > 0:
         s = "s" if errors > 1 else ""
-        log.error(f"{errors} error{s} encountered while installing hub packages, aborting...")
+        log.error("%s error%s encountered while installing hub packages, aborting..." % (errors, s))
         return errors
 
     client_jobs = []
@@ -230,7 +230,7 @@ def install(
 
     if errors > 0:
         s = "s" if errors > 1 else ""
-        log.error(f"{errors} error{s} encountered while installing client packages")
+        log.error("%s error%s encountered while installing client packages" % (errors, s))
 
     return errors
 
@@ -696,10 +696,10 @@ def deploy(hubs, masterfiles):
         paths = _download_urls(urls)
         assert len(paths) == 1
         masterfiles = paths[0]
-        log.debug(f"Deploying downloaded: {masterfiles}")
+        log.debug("Deploying downloaded: %s" % masterfiles)
     else:
         masterfiles = os.path.abspath(os.path.expanduser(masterfiles))
-        log.debug(f"Deploy path expanded to: {masterfiles}")
+        log.debug("Deploy path expanded to: %s" % masterfiles)
 
     masterfiles = masterfiles.rstrip("/")
 
@@ -716,7 +716,7 @@ def deploy(hubs, masterfiles):
             return 1
 
     if not os.path.isdir(masterfiles):
-        log.error(f"'{masterfiles}' must be a directory")
+        log.error("'%s' must be a directory" % masterfiles)
         return 1
 
     directory = masterfiles
@@ -725,25 +725,25 @@ def deploy(hubs, masterfiles):
         log.error("The masterfiles directory to deploy must be called 'masterfiles'")
         return 1
 
-    if os.path.isfile(f"{directory}/autogen.sh"):
-        os.system(f"bash -c 'cd {directory} && ./autogen.sh 1>/dev/null 2>&1'")
-        if not os.path.isfile(f"{directory}/promises.cf"):
-            log.error(f"The autogen.sh script did not produce promises.cf in '{directory}'")
+    if os.path.isfile("%s/autogen.sh" % directory):
+        os.system("bash -c 'cd %s && ./autogen.sh 1>/dev/null 2>&1'" % directory)
+        if not os.path.isfile("%s/promises.cf" % directory):
+            log.error("The autogen.sh script did not produce promises.cf in '%s'" % directory)
             return 1
-    elif os.path.isfile(f"{directory}/configure"):
-        os.system(f"bash -c 'cd {directory} && ./configure 1>/dev/null 2>&1'")
-        if not os.path.isfile(f"{directory}/promises.cf"):
-            log.error(f"The configure script did not produce promises.cf in '{directory}'")
+    elif os.path.isfile("%s/configure" % directory):
+        os.system("bash -c 'cd %s && ./configure 1>/dev/null 2>&1'" % directory)
+        if not os.path.isfile("%s/promises.cf" % directory):
+            log.error("The configure script did not produce promises.cf in '%s'" % directory)
             return 1
     else:
         log.debug("No autogen.sh / configure found, assuming ready to install directory")
-        if not os.path.isfile(f"{directory}/promises.cf"):
-            log.error(f"No promises.cf in '{directory}'")
+        if not os.path.isfile("%s/promises.cf" % directory):
+            log.error("No promises.cf in '%s'" % directory)
             return 1
 
     assert(not cf_remote_dir().endswith("/"))
     tarball = cf_remote_dir() + "/masterfiles.tgz"
     above = directory[0:-len("/masterfiles")]
-    os.system(f"rm -rf {tarball}")
-    os.system(f"tar -czf {tarball} -C {above} masterfiles")
+    os.system("rm -rf %s" % tarball)
+    os.system("tar -czf %s -C %s masterfiles" % (tarball, above))
     return deploy_tarball(hubs, tarball)

--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -12,7 +12,7 @@ from cf_remote.spawn import Providers
 
 
 def print_version_info():
-    print(f"cf-remote version {version.string()}")
+    print("cf-remote version %s" % version.string())
     print("Available CFEngine versions:")
     releases = Releases()
     print(releases)
@@ -234,13 +234,13 @@ def validate_command(command, args):
                 "--package cannot be used in combination with --hub-package / --client-package")
         if args.package and not is_package_url(args.package):
             if not os.path.exists(os.path.expanduser(args.package)):
-                user_error(f"Package/directory '{args.package}' does not exist")
+                user_error("Package/directory '%s' does not exist" % args.package)
         if args.hub_package and not is_package_url(args.hub_package):
             if not os.path.isfile(args.hub_package):
-                user_error(f"Hub package '{args.hub_package}' does not exist")
+                user_error("Hub package '%s' does not exist" % args.hub_package)
         if args.client_package and not is_package_url(args.client_package):
             if not os.path.isfile(args.client_package):
-                user_error(f"Client package '{args.client_package}' does not exist")
+                user_error("Client package '%s' does not exist" % args.client_package)
 
     if command in ["sudo", "run"]:
         if len(args.remote_command) != 1:
@@ -269,7 +269,7 @@ def validate_command(command, args):
             if not masterfiles.endswith((".tgz", ".tar.gz")):
                 user_error("masterfiles URL must be to a gzipped tarball (.tgz or .tar.gz)")
         elif not os.path.exists(masterfiles):
-            user_error(f"'{masterfiles}' does not exist")
+            user_error("'%s' does not exist" % masterfiles)
 
 
 def is_in_cloud_state(name):

--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -324,7 +324,7 @@ def install_host(
         return 1
 
     if remote_download:
-        print(f"Downloading '{package}' on '{host}' using curl")
+        print("Downloading '%s' on '%s' using curl" % (package, host))
         r = ssh_cmd(cmd="curl --fail -O {}".format(package), connection=connection, errors=True)
         if r is None:
             return 1
@@ -404,13 +404,13 @@ def deploy_masterfiles(host, tarball, *, connection=None):
     print("\nDeploying to:")
     print_info(data)
     if not data["agent_version"]:
-        log.error(f"Cannot deploy masterfiles on {host} - CFEngine not installed")
+        log.error("Cannot deploy masterfiles on %s - CFEngine not installed" % host)
         return 1
 
     if not getattr(connection, 'is_local', False):
         scp(tarball, host, connection=connection, rename="masterfiles.tgz")
         tarball = "masterfiles.tgz"
-    ssh_cmd(connection, f"tar -xzf {tarball}")
+    ssh_cmd(connection, "tar -xzf %s" % tarball)
     commands = [
         "rm -rf /var/cfengine/masterfiles.delete",
         "mv /var/cfengine/masterfiles /var/cfengine/masterfiles.delete",
@@ -420,6 +420,6 @@ def deploy_masterfiles(host, tarball, *, connection=None):
         "cf-agent -K",
     ]
     combined = " && ".join(commands)
-    print(f"Running: '{combined}'")
+    print("Running: '%s'" % combined)
     ssh_sudo(connection, combined)
     return 0

--- a/cf_remote/ssh.py
+++ b/cf_remote/ssh.py
@@ -56,8 +56,8 @@ class Connection:
 
 
 def connect(host, users=None):
-    log.debug(f"Connecting to '{host}'")
-    log.debug(f"users= '{users}'")
+    log.debug("Connecting to '%s'" % host)
+    log.debug("users= '%s'" % users)
     if "@" in host:
         parts = host.split("@")
         assert len(parts) == 2
@@ -80,7 +80,7 @@ def connect(host, users=None):
             users = [whoami()] + users
     for user in users:
         try:
-            log.debug(f"Attempting ssh: {user}@{host}")
+            log.debug("Attempting ssh: %s@%s" % (user, host))
             connect_kwargs = {}
             key = os.getenv("CF_REMOTE_SSH_KEY")
             if key:
@@ -92,7 +92,7 @@ def connect(host, users=None):
             return c
         except aramid.ExecutionError:
             continue
-    sys.exit(f"Could not ssh into '{host}'")
+    sys.exit("Could not ssh into '%s'" % host)
 
 
 # Decorator to make a function automatically connect
@@ -119,28 +119,28 @@ def scp(file, remote, connection=None, rename=None):
         with connect(remote) as connection:
             scp(file, remote, connection, rename)
     else:
-        print(f"Copying: '{file}' to '{remote}'")
+        print("Copying: '%s' to '%s'" % (file, remote))
         connection.put(file)
         if rename:
             file = os.path.basename(file)
             if file == rename:
                 return 0
-            print(f"Renaming '{file}' -> '{rename}' on '{remote}'")
-            ssh_cmd(connection, f"mv {file} {rename}")
+            print("Renaming '%s' -> '%s' on '%s'" % (file, rename, remote))
+            ssh_cmd(connection, "mv %s %s" % (file, rename))
     return 0
 
 
 def ssh_cmd(connection, cmd, errors=False):
     assert connection
 
-    log.debug(f"Running over SSH: '{cmd}'")
+    log.debug("Running over SSH: '%s'" % cmd)
     result = connection.run(cmd, hide=True)
     if result.retcode == 0:
         output = result.stdout.replace("\r\n", "\n").strip("\n")
-        log.debug(f"'{cmd}' -> '{output}'")
+        log.debug("'%s' -> '%s'" % (cmd, output))
         return output
     else:
-        msg = f"Non-sudo command unexpectedly exited: '{cmd}' [{result.retcode}]"
+        msg = "Non-sudo command unexpectedly exited: '%s' [%d]" % (cmd, result.retcode)
         if errors:
             print(result.stdout + result.stderr)
             log.error(msg)
@@ -153,16 +153,16 @@ def ssh_cmd(connection, cmd, errors=False):
 def ssh_sudo(connection, cmd, errors=False):
     assert connection
 
-    log.debug(f"Running(sudo) over SSH: '{cmd}'")
+    log.debug("Running(sudo) over SSH: '%s'" %cmd)
     escaped = cmd.replace('"', r"\"")
-    sudo_cmd = f'sudo bash -c "{escaped}"'
+    sudo_cmd = 'sudo bash -c "%s"' % escaped
     result = connection.run(sudo_cmd, hide=True)
     if result.retcode == 0:
         output = result.stdout.strip("\n")
-        log.debug(f"'{cmd}' -> '{output}'")
+        log.debug("'%s' -> '%s'" % (cmd, output))
         return output
     else:
-        msg = f"Sudo command unexpectedly exited: '{cmd}' [{result.retcode}]"
+        msg = "Sudo command unexpectedly exited: '%s' [%d]" % (cmd, result.retcode)
         if errors:
             print(result.stdout + result.stderr)
             log.error(msg)

--- a/cf_remote/utils.py
+++ b/cf_remote/utils.py
@@ -40,7 +40,7 @@ def canonify(string):
 
 
 def user_error(msg):
-    sys.exit(f"{os.path.basename(sys.argv[0])}: " + msg)
+    sys.exit("%s: " % os.path.basename(sys.argv[0]) + msg)
 
 
 def exit_success():

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.5",
     entry_points={"console_scripts": ["cf-remote = cf_remote.main:main"]},
     install_requires=[
         "requests >= 2.25.1",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ assert "." in cf_remote_version
 
 assert os.path.isfile("cf_remote/version.py")
 with open("cf_remote/VERSION", "w", encoding="utf-8") as fh:
-    fh.write(f"{cf_remote_version}\n")
+    fh.write("%s\n" % cf_remote_version)
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/test/test_example.py
+++ b/test/test_example.py
@@ -1,0 +1,2 @@
+def test_example():
+    assert 2 + 2 == 4


### PR DESCRIPTION
For cfbs to be python 3.5 compatible, its dependency cf-remote must also
be python 3.5 compatible.

Ticket: CFE-3792
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>