### PR TITLE
Fix --remote-download to install the downloaded package

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -309,6 +309,7 @@ def install_host(
         r = ssh_cmd(cmd="curl --fail -O {}".format(package), connection=connection, errors=True)
         if r is None:
             return 1
+        package = basename(package)
     elif not getattr(connection, 'is_local', False):
         scp(package, host, connection=connection)
         package = basename(package)


### PR DESCRIPTION
This was broken in e61ed477e4. The install_package() function
needs to be called with the downloaded package, not its URL.

Ticket: CFE-3869
Changelog: None