### PR TITLE
Added save command for adding hosts spawned elsewhere

### DIFF
--- a/cf_remote/commands.py
+++ b/cf_remote/commands.py
@@ -360,9 +360,7 @@ def spawn(platform, count, role, group_name, provider=Providers.AWS, region=None
 
 def _is_saved_group(vms_info, group_name):
     group = vms_info[group_name]
-    return ("meta" not in group
-            or "region" not in group["meta"]
-            or "provider" not in group["meta"])
+    return (group.get("meta", {}).get("saved") == True)
 
 def _delete_saved_group(vms_info, group_name):
     print("Deleting saved group '{}' without terminating VMs:".format(group_name))
@@ -516,18 +514,18 @@ def save(name, hosts, role):
     if "@" + name in state:
         print("Group '{}' already exists".format(name))
         return 1
-    group = {}
-    group["meta"] = {}
+    group = {"meta": {"saved": True}}
     for index, host in enumerate(hosts):
         split = host.split("@")
         if len(split) != 2:
             print("Host '{}' not accepted, must be given as user@ip-address".format(host))
             return 1
         user, ip = host.split("@")
-        instance = {}
-        instance["public_ips"] = [ip]
-        instance["user"] = user
-        instance["role"] = role
+        instance = {
+            "public_ips": [ip],
+            "user": user,
+            "role": role,
+        }
         group[name + "-" + str(index + 1)] = instance
     state["@" + name] = group
     write_json(CLOUD_STATE_FPATH, state)

--- a/cf_remote/commands.py
+++ b/cf_remote/commands.py
@@ -358,6 +358,20 @@ def spawn(platform, count, role, group_name, provider=Providers.AWS, region=None
 
     return 0
 
+def _is_saved_group(vms_info, group_name):
+    group = vms_info[group_name]
+    return ("meta" not in group
+            or "region" not in group["meta"]
+            or "provider" not in group["meta"])
+
+def _delete_saved_group(vms_info, group_name):
+    print("Deleting saved group '{}' without terminating VMs:".format(group_name))
+    for name, vm in vms_info[group_name].items():
+        if name == "meta":
+            continue
+        print("  {}: {}@{} ({})".format(name, vm["user"], vm["public_ips"][0], vm["role"]))
+    del vms_info[group_name]
+
 def destroy(group_name=None):
     if os.path.exists(CLOUD_CONFIG_FPATH):
         creds_data = read_json(CLOUD_CONFIG_FPATH)
@@ -392,12 +406,18 @@ def destroy(group_name=None):
 
     to_destroy = []
     if group_name:
-        print("Destroying hosts in the '%s' group" % group_name)
         if not group_name.startswith("@"):
             group_name = "@" + group_name
         if group_name not in vms_info:
             print("Group '%s' not found" % group_name)
             return 1
+
+        if (_is_saved_group(vms_info, group_name)):
+            _delete_saved_group(vms_info, group_name)
+            write_json(CLOUD_STATE_FPATH, vms_info)
+            return 0
+
+        print("Destroying hosts in the '%s' group" % group_name)
 
         region = vms_info[group_name]["meta"]["region"]
         provider = vms_info[group_name]["meta"]["provider"]
@@ -426,6 +446,10 @@ def destroy(group_name=None):
     else:
         print("Destroying all hosts")
         for group_name in [key for key in vms_info.keys() if key.startswith("@")]:
+            if (_is_saved_group(vms_info, group_name)):
+                _delete_saved_group(vms_info, group_name)
+                continue
+
             region = vms_info[group_name]["meta"]["region"]
             provider = vms_info[group_name]["meta"]["provider"]
             if provider == "aws":
@@ -482,6 +506,31 @@ def init_cloud_config():
     }
     write_json(CLOUD_CONFIG_FPATH, empty_config)
     print("Config file %s created, please complete the configuration in it." % CLOUD_CONFIG_FPATH)
+    return 0
+
+
+def save(name, hosts, role):
+    state = read_json(CLOUD_STATE_FPATH)
+    if not state:
+        state = {}
+    if "@" + name in state:
+        print("Group '{}' already exists".format(name))
+        return 1
+    group = {}
+    group["meta"] = {}
+    for index, host in enumerate(hosts):
+        split = host.split("@")
+        if len(split) != 2:
+            print("Host '{}' not accepted, must be given as user@ip-address".format(host))
+            return 1
+        user, ip = host.split("@")
+        instance = {}
+        instance["public_ips"] = [ip]
+        instance["user"] = user
+        instance["role"] = role
+        group[name + "-" + str(index + 1)] = instance
+    state["@" + name] = group
+    write_json(CLOUD_STATE_FPATH, state)
     return 0
 
 

--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -76,6 +76,11 @@ def get_args():
     sp.add_argument("--raw", help="Print only output of command itself", action='store_true')
     sp.add_argument("remote_command", help="Command to execute on remote host (including args)", type=str, nargs=1)
 
+    sp = subp.add_parser("save", help="Spawn hosts in the clouds")
+    sp.add_argument("--role", help="Role of the hosts", choices=["hub", "hubs", "client", "clients"], required=True)
+    sp.add_argument("--name", help="Name of the group of hosts (can be used in other commands)", required=True)
+    sp.add_argument("--hosts", "-H", help="SSH usernames and IPs for SSH and CFEngine in the form of user@ip", required=True)
+
     sp = subp.add_parser("sudo",
                          help="Run the command given as arguments on the given hosts with 'sudo'")
     sp.add_argument("--hosts", "-H", help="Which hosts to run the command on", type=str, required=True)
@@ -154,6 +159,8 @@ def run_command_with_args(command, args):
         return commands.download(tags=args.tags, version=args.version, edition=args.edition)
     elif command == "run":
         return commands.run(hosts=args.hosts, raw=args.raw, command=args.remote_command)
+    elif command == "save":
+        return commands.save(hosts=args.hosts, role=args.role, name=args.name)
     elif command == "sudo":
         return commands.sudo(hosts=args.hosts, raw=args.raw, command=args.remote_command)
     elif command == "scp":
@@ -313,7 +320,7 @@ def get_cloud_hosts(name, private_ips=False):
 
     ret = []
     for host in hosts:
-        if private_ips:
+        if private_ips and "private_ips" in host:
             key = "private_ips"
         else:
             key = "public_ips"

--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -289,7 +289,7 @@ def is_in_cloud_state(name):
     return False
 
 
-def get_cloud_hosts(name, private_ips=False):
+def get_cloud_hosts(name, bootstrap_ips=False):
     if not os.path.exists(paths.CLOUD_STATE_FPATH):
         return []
 
@@ -320,7 +320,7 @@ def get_cloud_hosts(name, private_ips=False):
 
     ret = []
     for host in hosts:
-        if private_ips and "private_ips" in host:
+        if bootstrap_ips and "private_ips" in host:
             key = "private_ips"
         else:
             key = "public_ips"
@@ -337,7 +337,7 @@ def get_cloud_hosts(name, private_ips=False):
     return ret
 
 
-def resolve_hosts(string, single=False, private_ips=False):
+def resolve_hosts(string, single=False, bootstrap_ips=False):
     log.debug("resolving hosts from '{}'".format(string))
     if is_file_string(string):
         names = expand_list_from_file(string)
@@ -348,7 +348,7 @@ def resolve_hosts(string, single=False, private_ips=False):
 
     for name in names:
         if is_in_cloud_state(name):
-            hosts = get_cloud_hosts(name, private_ips)
+            hosts = get_cloud_hosts(name, bootstrap_ips)
             ret.extend(hosts)
             log.debug("found in cloud, adding '{}'".format(hosts))
         else:
@@ -377,7 +377,7 @@ def validate_args(args):
         args.clients = resolve_hosts(args.clients)
     if "bootstrap" in args and args.bootstrap:
         args.bootstrap = [
-            strip_user(host_info) for host_info in resolve_hosts(args.bootstrap, private_ips=True)
+            strip_user(host_info) for host_info in resolve_hosts(args.bootstrap, bootstrap_ips=True)
         ]
     if "hub" in args and args.hub:
         args.hub = resolve_hosts(args.hub)


### PR DESCRIPTION
No support for private IPs (yet).

Looks like this:

```
$ cf-remote save -H root@198.211.105.11,root@128.199.44.119 --role hub --name hubs
$ cf-remote info -H hubs

root@198.211.105.11
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : 3.18.1 (Enterprise)
Policy server : 198.211.105.11
Binaries      : dpkg, apt

root@128.199.44.119
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : 3.18.1 (Enterprise)
Policy server : 128.199.44.119
Binaries      : dpkg, apt

$ cf-remote destroy --all
Destroying all hosts
Deleting saved group '@hubs' without terminating VMs:
  hubs-1: root@198.211.105.11 (hub)
  hubs-2: root@128.199.44.119 (hub)
```