### PR TITLE
deploy command now uses spawned / saved hubs and cfbs policy set by default

### DIFF
--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -118,8 +118,8 @@ def _get_arg_parser():
     dp.add_argument("name", help="Name fo the group of hosts to destroy", nargs='?')
 
     sp = subp.add_parser("deploy", help="Deploy masterfiles to hub")
-    sp.add_argument("--hub", help="Hub(s) to deploy to", type=str, required=True)
-    sp.add_argument("masterfiles", help="Path to local masterfiles directory or tarball", type=str)
+    sp.add_argument("--hub", help="Hub(s) to deploy to", type=str)
+    sp.add_argument("masterfiles", help="Path to local masterfiles directory or tarball", type=str, nargs="?")
 
     return ap
 
@@ -263,16 +263,13 @@ def validate_command(command, args):
         if not args.all and not args.name:
             user_error("One of --all or NAME required for destroy")
 
-    if command == "deploy":
-        if not args.masterfiles:
-            user_error("Must specify a path to masterfiles")
-        if not args.hub:
-            user_error("Must specify at least one hub")
-        if args.masterfiles.startswith(("http://", "https://")):
-            if not args.masterfiles.endswith((".tgz", ".tar.gz")):
+    if command == "deploy" and args.masterfiles:
+        masterfiles = args.masterfiles
+        if masterfiles.startswith(("http://", "https://")):
+            if not masterfiles.endswith((".tgz", ".tar.gz")):
                 user_error("masterfiles URL must be to a gzipped tarball (.tgz or .tar.gz)")
-        elif not os.path.exists(args.masterfiles):
-            user_error(f"'{args.masterfiles}' does not exist")
+        elif not os.path.exists(masterfiles):
+            user_error(f"'{masterfiles}' does not exist")
 
 
 def is_in_cloud_state(name):


### PR DESCRIPTION
Example:

```
$ cf-remote deploy
Found saved/spawned hubs: ubuntu@54.154.69.41
Found cfbs policy set: 'out/masterfiles.tgz'

Deploying to:

ubuntu@54.154.69.41
OS            : ubuntu (debian)
Architecture  : x86_64
CFEngine      : 3.18.1 (Enterprise)
Policy server : None
Binaries      : dpkg, apt

Copying: 'out/masterfiles.tgz' to 'ubuntu@54.154.69.41'
Renaming 'masterfiles.tgz' -> 'masterfiles.tgz' on 'ubuntu@54.154.69.41'
Running: 'rm -rf /var/cfengine/masterfiles.delete && mv /var/cfengine/masterfiles /var/cfengine/masterfiles.delete && mv masterfiles /var/cfengine/masterfiles && rm -rf /var/cfengine/masterfiles.delete && cf-agent -Kf update.cf && cf-agent -K'
```

Ticket: https://tracker.mender.io/browse/CFE-3930