### PR TITLE
Remove tabulate from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ fabric==2.6.0
 paramiko==2.10.1
 requests==2.25.1
 apache-libcloud==3.3.1
-tabulate==0.8.9


### PR DESCRIPTION
It's not imported and used anywhere in the code since
05ddc5287b5d.