### PR TITLE
Fixed broken file transfer introduced by aramid

### DIFF
--- a/cf_remote/ssh.py
+++ b/cf_remote/ssh.py
@@ -43,8 +43,9 @@ class Connection:
         return results[ahost][0]
 
     def put(self, src):
+        dst = os.path.basename(src)
         ahost = aramid.Host(self.ssh_host, self.ssh_user)
-        results = aramid.put([ahost], src)
+        results = aramid.put([ahost], src, dst)
         return results[ahost][0].retcode
 
     def __enter__(self, *args, **kwargs):


### PR DESCRIPTION
scp and cf-remote default to transferring files to the home folder,
where you end up if you ssh to the machine. aramid defaults to
using the same path as in src, which might not exist or be accessible.
Restored the previous behavior by explicitly giving destination
path to aramid library.