### PR TITLE
Added options for allowing ssh-rsa by default

### DIFF
--- a/cf_remote/aramid.py
+++ b/cf_remote/aramid.py
@@ -28,7 +28,7 @@ from collections import namedtuple
 import subprocess
 import time
 
-DEFAULT_SSH_ARGS = ["-o", "LogLevel=ERROR", "-o", "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes"]
+DEFAULT_SSH_ARGS = ["-oLogLevel=ERROR", "-oUserKnownHostsFile=/dev/null", "-oStrictHostKeyChecking=no", "-oBatchMode=yes", "-oHostKeyAlgorithms=+ssh-rsa",  "-oPubkeyAcceptedKeyTypes=+ssh-rsa"]
 """Default arguments to use with all SSH commands (incl. 'scp' and 'rsync')"""
 
 PRINT_OUT_FN = print


### PR DESCRIPTION
Newer SSH clients try disabling ssh-rsa by default.
ssh-rsa is still used, notably by the CentOS 6 machines in AWS.
Since we support CentOS 6 and want cf-remote to "just work",
we will enable this by default. People should still / independently
of this ensure they are not using SHA-1, and also that they switch
away from ssh-rsa on their SSH servers.