### PR TITLE
Remove non-existent AMI

### DIFF
--- a/cf_remote/cloud_data.py
+++ b/cf_remote/cloud_data.py
@@ -82,11 +82,6 @@ aws_platforms = {
         "user": "ec2-user",
         "xlsize": "m3.xlarge"
     },
-    "coreos": {
-        "ami": "ami-067301c1a68e593f5",
-        "size": "t3a.nano",
-        "user": "core"
-    },
     'centos-5-x32':{
         'ami':'ami-fe11398a',
         'user':'root',


### PR DESCRIPTION
Apparently the CoreOS AMI does not exist.
```
$  cf-remote spawn --platform coreos --name coreos --count 1 --role client
Spawning VMs...Traceback (most recent call last):
  File "/usr/local/bin/cf-remote", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.10/site-packages/cf_remote/main.py", line 399, in main
    exit_code = run_command_with_args(args.command, args)
  File "/usr/local/lib/python3.10/site-packages/cf_remote/main.py", line 196, in run_command_with_args
    return commands.spawn(args.platform, args.count, args.role, args.name,
  File "/usr/local/lib/python3.10/site-packages/cf_remote/commands.py", line 335, in spawn
    vms = spawn_vms(requests, creds, region, key_pair,
  File "/usr/local/lib/python3.10/site-packages/cf_remote/spawn.py", line 369, in spawn_vms
    vm = spawn_vm_in_aws(req.platform, creds, key_pair, security_groups,
  File "/usr/local/lib/python3.10/site-packages/cf_remote/spawn.py", line 284, in spawn_vm_in_aws
    node = driver.create_node(
  File "/usr/local/lib/python3.10/site-packages/libcloud/compute/drivers/ec2.py", line 1764, in create_node
    object = self.connection.request(self.path, params=params).object
  File "/usr/local/lib/python3.10/site-packages/libcloud/common/base.py", line 659, in request
    return request_to_be_executed(
  File "/usr/local/lib/python3.10/site-packages/libcloud/common/base.py", line 721, in _retryable_request
    response = responseCls(**kwargs)
  File "/usr/local/lib/python3.10/site-packages/libcloud/common/base.py", line 165, in __init__
    raise exception_from_message(
libcloud.common.exceptions.BaseHTTPError: InvalidAMIID.NotFound: The image id '[ami-067301c1a68e593f5]' does not exist
```