### PR TITLE
CFE-4024: Fixed print/debug messages when running commands on localhost

### DIFF
--- a/cf_remote/ssh.py
+++ b/cf_remote/ssh.py
@@ -176,7 +176,8 @@ def ssh_cmd(connection, cmd, errors=False):
     else:
         msg = "Non-sudo command unexpectedly exited: '%s' [%d]" % (cmd, result.retcode)
         if errors:
-            print(result.stdout + result.stderr)
+            print(result.stdout if result.stdout is not None else "")
+            print(result.stderr if result.stderr is not None else "")
             log.error(msg)
         else:
             log.debug(result.stdout if result.stdout is not None else "")
@@ -199,9 +200,11 @@ def ssh_sudo(connection, cmd, errors=False):
     else:
         msg = "Sudo command unexpectedly exited: '%s' [%d]" % (cmd, result.retcode)
         if errors:
-            print(result.stdout + result.stderr)
+            print(result.stdout if result.stdout is not None else "")
+            print(result.stderr if result.stderr is not None else "")
             log.error(msg)
         else:
-            log.debug(result.stdout + result.stderr)
+            log.debug(result.stdout if result.stdout is not None else "")
+            log.debug(result.stderr if result.stderr is not None else "")
             log.debug(msg)
         return None


### PR DESCRIPTION
Fixed some earlier here: a77369aedb52a6869fe45b6cda3195e5ef8f2839 but missed a few.

The underlying issue is that aramid result.stdout and stderr
are strings but when we connect to localhost we use a subprocess
and result.stdout/stderr are byte sequences and so can't be appended
to each other as strings can.

Ticket: CFE-4024
Changelog: title