### PR TITLE
Fixed package selection for x86_64/amd64

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -366,6 +366,8 @@ def get_package_from_host_info(
         tags.append("arm64")
     if arch in ("i386", "i486", "i586", "i686"):
         tags.append("32")
+    if arch in ("x86_64", "amd64"):
+        tags.append(arch)
 
     extension = None
     if package_tags is not None and "msi" in package_tags:


### PR DESCRIPTION
In some cases the arm64/aarch64 package might be selected instead.

Ticket: CFE-4049
Changelog: title