### PR TITLE
CFE-4150: Fixed bug when installing packages containing spaces

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -222,7 +222,7 @@ def install_package(host, pkg, data, *, connection=None):
 
     print("Installing: '{}' on '{}'".format(pkg, host))
     if ".deb" in pkg:
-        output = ssh_sudo(connection, "dpkg -i {}".format(pkg), True)
+        output = ssh_sudo(connection, 'dpkg -i "{}"'.format(pkg), True)
     elif ".msi" in pkg:
         # Windows is crazy, be careful if you decide to change this;
         # This needs to work in both powershell and cmd, and in


### PR DESCRIPTION
Fixed bug where installing packages containing spaces and parenthesis in
the filename would result in a syntax error in the remote shell.