### PR TITLE
Stopped suggesting debian packages for ubuntu hosts

### DIFF
--- a/cf_remote/packages.py
+++ b/cf_remote/packages.py
@@ -103,30 +103,6 @@ class Artifact:
             self.add_tag("opensuse-leap15")
             self.add_tag("opensuse-leap")
 
-        # sorry, debian packages work great on ubuntu
-        # if we don't have a specific ubuntu package, note which debian is equivalent
-        # only add "ubuntu" tag if we know we have an equivalent debian :)
-        if "debian11" in self.tags:
-            self.add_tag("ubuntu20")
-            self.add_tag("ubuntu")
-        if "debian10" in self.tags:
-            self.add_tag("ubuntu19")
-            self.add_tag("ubuntu18")
-            self.add_tag("ubuntu")
-        if "debian9" in self.tags:
-            self.add_tag("ubuntu17")
-            self.add_tag("ubuntu16")
-            self.add_tag("ubuntu")
-        if "debian8" in self.tags:
-            self.add_tag("ubuntu15")
-            self.add_tag("ubuntu14")
-            self.add_tag("ubuntu")
-        if "debian7" in self.tags:
-            self.add_tag("ubuntu13")
-            self.add_tag("ubuntu12")
-            self.add_tag("ubuntu11")
-            self.add_tag("ubuntu")
-
         parts = filename.split(".")
         if "x86_64" in parts:
             self.add_tag("x86_64")

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -24,10 +24,6 @@ def test_release():
         == "cfengine-nova-hub_3.21.0a.138df3742~21749.debian11_arm64.deb"
     )
     assert "hub" in found[0].tags
-    assert (
-        found[1].filename == "cfengine-nova_3.21.0a.138df3742~21749.debian11_arm64.deb"
-    )
-    assert "hub" not in found[1].tags
 
     found = release.find(["aarch64", "ubuntu22"])
     assert (


### PR DESCRIPTION
We have specific packages for all of these Ubuntu and Debian choices,
so it's better if we don't suggest the "wrong" package.
