### PR TITLE
ENT-10479: Added support for installing Red Hat packages on Rocky and Alma Linux

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -130,15 +130,15 @@ def get_package_tags(os_release=None, redhat_release=None):
 
         # Add tags with version number first, to filter by them first:
         tags.append(platform_tag)  # Example: ubuntu16
-        if distro == "centos" or distro == "rhel" or distro == "ol":
+        if distro == "centos" or distro == "rhel" or distro == "ol" or distro == "rocky" or distro == "almalinux":
             tags.append("el" + major)
 
         # Then add more generic tags (lower priority):
         tags.append(distro)  # Example: ubuntu
-        if distro == "centos" or distro == "ol":
+        if distro == "centos" or distro == "ol" or distro == "rocky" or distro == "almalinux":
             tags.append("rhel")
 
-        if distro == "centos" or distro == "rhel" or distro == "ol":
+        if distro == "centos" or distro == "rhel" or distro == "ol" or distro == "rocky" or distro == "almalinux":
             tags.append("el")
     elif redhat_release is not None:
         # Examples:


### PR DESCRIPTION
This change makes cf-remote install Red Hat packages on Rocky and Alma Linux as
they are both derivatives of Red Hat.

Ticket: ENT-10479
Changelog: Title