### PR TITLE
ENT-10347: Added Debian 12 x86_64 AMI to cf-remote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 /venv
 /.venv
 __pycache__/
+**/.DS_STORE

--- a/cf_remote/cloud_data.py
+++ b/cf_remote/cloud_data.py
@@ -64,6 +64,12 @@ aws_platforms = {
         "size": "t1.micro",
         "xlsize": "m3.xlarge",
     },
+    "debian-12-x64": {
+        "ami": "ami-07024fbdfd1aab8a0",
+        "user": "admin",
+        "size": "t1.micro",
+        "xlsize": "m3.xlarge",
+    },
     "centos-6-x64": {
         "ami": "ami-05bd23226cb7c2896",
         "user": "centos",


### PR DESCRIPTION
```
larsewi@zyra:cf-remote % cf-remote spawn --platform debian-12-x64 --count 1 --role hub --name test
---snip---
larsewi@zyra:cf-remote % cf-remote show
@test: (1 host in eu-west-1, aws)
  admin@54.72.6.161
    hub, latest-debian-12-x64hub0, debian-12-x64, m3.xlarge, 172.31.25.167, 
    54.72.6.161, 59d02ac536cea38915173a2295601f9d4b8107ba, larsewi-ed25519, 
    cfengine-test


Total: 1 host in 1 group
larsewi@zyra:cf-remote % ssh admin@54.72.6.161
---snip---
admin@ip-172-31-25-167:~$ cat /etc/os-release 
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
admin@ip-172-31-25-167:~$ 
logout
Connection to 54.72.6.161 closed.
```