### PR TITLE
cloud_data.py: Added SUSE 15 & 12 AMI's

### DIFF
--- a/cf_remote/cloud_data.py
+++ b/cf_remote/cloud_data.py
@@ -158,4 +158,16 @@ aws_platforms = {
         "size": "t2.small",
         "xlsize": "t2.xlarge",
     },
+    "suse-12-x64": {
+        "ami": "ami-0d5622d69a166848b",
+        "user": "ec2-user",
+        "size": "t2.small",
+        "xlsize": "t2.xlarge",
+    },
+    "suse-15-x64": {
+        "ami": "ami-0e5e442298b8e7f5a",
+        "user": "ec2-user",
+        "size": "t2.small",
+        "xlsize": "t2.xlarge",
+    },
 }


### PR DESCRIPTION
```
$ cf-remote spawn --platform suse-15-x64 --count 1 --role client --name suse-15
Spawning VMs....DONE
Waiting for VMs to get IP addresses....DONE
Details about the spawned VMs can be found in /Users/larsewi/.cfengine/cf-remote/cloud_state.json
$ cf-remote spawn --platform suse-12-x64 --count 1 --role client --name suse-12
Spawning VMs....DONE
Waiting for VMs to get IP addresses....DONE
Details about the spawned VMs can be found in /Users/larsewi/.cfengine/cf-remote/cloud_state.json
$ cf-remote show
@suse-15: (1 host in eu-west-1, aws)
  ec2-user@52.50.182.71
    client, lasuse-15-suse-15-x64client0, suse-15-x64, t2.xlarge, 
    172.31.41.148, 52.50.182.71, 63b7362ac1e27cae0b32014aa18644ed07198c69, 
    larsewi-ed25519, cfengine-test


@suse-12: (1 host in eu-west-1, aws)
  ec2-user@3.253.61.16
    client, lasuse-12-suse-12-x64client0, suse-12-x64, t2.xlarge, 
    172.31.47.135, 3.253.61.16, 37aa1d15064455a2380140b5141ea817ffd40564, 
    larsewi-ed25519, cfengine-test


Total: 2 hosts in 2 groups
```
