### PR TITLE
ENT-10985: error message when a release does not exist

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -354,6 +354,9 @@ def _package_from_releases(tags, extension, version, edition, remote_download):
     release = releases.default
     if version:
         release = releases.pick_version(version)
+    if release is None:
+        print("Could not find a release for version {}".format(version))
+        return None
 
     release.init_download()
 


### PR DESCRIPTION
Error message:
![image](https://github.com/cfengine/cf-remote/assets/23060634/deb16536-fbf1-4ea4-a707-bc48f7ea79e8)

Ticket: ENT-10985
Changelog: None