### PR TITLE
CFE-4361: Fixed issue where policy server IP was not printed in info command

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -217,6 +217,12 @@ def get_info(host, *, users=None, connection=None):
         data["policy_server"] = ssh_cmd(
             connection, "cat /var/cfengine/policy_server.dat"
         )
+        if user != "root" and not data["policy_server"]:
+            # If we are not SSHing as root and we failed to read
+            # the policy_server.dat file try again using sudo:
+            data["policy_server"] = ssh_sudo(
+                connection, "cat /var/cfengine/policy_server.dat"
+            )
 
         agent = r"/var/cfengine/bin/cf-agent"
         data["agent"] = agent


### PR DESCRIPTION
sudo is already used / needed for other parts of cf-remote
(such as cf-remote install and deploy), so attempting to use it
here should be acceptable.

Ticket: CFE-4361