### PR TITLE
CFE-4407: added ubuntu-24 name pattern for aws image criteria

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
+    env:
+      # Temporary workaround for Python 3.5 failures - May 2024, see CFE-4395
+      PIP_TRUSTED_HOST: "pypi.python.org pypi.org files.pythonhosted.org"
     strategy:
       fail-fast: false
       matrix:

--- a/cf_remote/cloud_data.py
+++ b/cf_remote/cloud_data.py
@@ -28,6 +28,11 @@ aws_image_criteria = {
         "name_pattern": "ubuntu-pro-server/images/hvm-ssd/ubuntu-xenial-16.04-amd64-pro-server*",
         "user": "ubuntu",
     },
+    "ubuntu-24": {
+        "owner_id": "099720109477",
+        "name_pattern": "ubuntu/images/hvm-ssd-gp3/ubuntu-*-{version}*",
+        "user": "ubuntu",
+    },
     "ubuntu": {
         "owner_id": "099720109477",
         "name_pattern": "ubuntu/images/hvm-ssd/ubuntu-*-{version}*",


### PR DESCRIPTION
fourth point is the cause
![image](https://github.com/cfengine/cf-remote/assets/23060634/88d4bf97-2bf4-4861-b4bb-25912928e75e)

Ticket: CFE-4407
Changelog: None