### PR TITLE
Added helpful message about "not bootstrapped yet"

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -91,10 +91,15 @@ def print_info(data):
     agent_version = data["agent_version"]
     if agent_version:
         output["CFEngine"] = agent_version
+
+        policy_server = data.get("policy_server")
+        if policy_server :
+            output["Policy server"] = policy_server
+        else :
+            output["Policy server"] = "None (not bootstrapped yet)"
     else:
         output["CFEngine"] = "Not installed"
 
-    output["Policy server"] = data.get("policy_server")
 
     binaries = []
     if "bin" in data:


### PR DESCRIPTION
When installing, you can see that CFE is not installed:
![Screenshot from 2024-12-11 11-19-17](https://github.com/user-attachments/assets/83a47800-f1e6-49b9-a86f-4cfbfc705599)
Then we bootstrap and see that CFE is installed, but not bootstrapped yet
![Screenshot from 2024-12-11 11-20-38](https://github.com/user-attachments/assets/6013722a-36a9-4745-bec0-c971a003ea6c)
CFE installed and bootstrapped:
![Screenshot from 2024-12-11 11-17-20](https://github.com/user-attachments/assets/ca77e33c-22e2-4d89-a531-e44b5ad1cf88)

