### PR TITLE
Added connect command

### DIFF
--- a/cf_remote/commands.py
+++ b/cf_remote/commands.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import subprocess
 import sys
 import time
 from multiprocessing.dummy import Pool
@@ -929,5 +930,18 @@ def agent(hosts, bootstrap=None):
         output = run_command(host, command, sudo=True)
         if output:
             print(output)
+
+    return 0
+
+
+def connect_cmd(hosts):
+
+    assert hosts and len(hosts)
+
+    if len(hosts) > 1:
+        user_error("You can only connect to one host at a time")
+
+    print("Opening a SSH command shell...")
+    subprocess.run(["ssh", hosts[0]])
 
     return 0

--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -274,6 +274,11 @@ def _get_arg_parser():
     )
     sp.add_argument("--bootstrap", "-B", help="Which hub to bootstrap to", type=str)
 
+    sp = subp.add_parser("connect", help="Opens interactive ssh shell")
+    sp.add_argument(
+        "--hosts", "-H", help="Host to open the shell on", type=str, required=True
+    )
+
     return ap
 
 
@@ -388,6 +393,8 @@ def run_command_with_args(command, args):
         return commands.deploy(args.hub, args.masterfiles)
     elif command == "agent":
         return commands.agent(args.hosts, args.bootstrap)
+    elif command == "connect":
+        return commands.connect_cmd(args.hosts)
     else:
         user_error("Unknown command: '{}'".format(command))
 


### PR DESCRIPTION
```
(.venv) victor-moene@victomoe:~/ntech/cf-remote (ENT-5726-interactive-shell) $ python3 cf_remote connect -H vagrant
Opening a SSH command shell...
root@dev ~ $ ls
build  cfengine-nova-hub_3.24.1-1.ubuntu20_amd64.deb  nt-discovery.sh  snap
root@dev ~ $ cd /northern.tech/cfengine/
root@dev cfengine $ ls
core  enterprise  librsync  masterfiles  nova  starter_pack  test-core.sh  test.sh
root@dev cfengine $ logout
Connection to 192.168.56.10 closed.
```

You can now ssh into any machine with connect like a normal shell