### PR TITLE
Added aws alpine platform Had to specify t3 instead of t2 as alpine images require EUFI which are available in t3.

### DIFF
--- a/cf_remote/cloud_data.py
+++ b/cf_remote/cloud_data.py
@@ -18,6 +18,21 @@ aws_image_criteria = {
         "name_pattern": "debian-{version}*",
         "user": "admin",
     },
+    "alpine": {
+        "owner_id": "538276064493",
+        "name_pattern": "alpine-{version}-*",
+        "user": "alpine",
+        "sizes": {
+            "x86_64": {
+                "size": "t3.micro",
+                "xlsize": "t3.xlarge",
+            },
+            "arm64": {
+                "size": "t4g.micro",
+                "xlsize": "t4g.xlarge",
+            },
+        },
+    },
     "ubuntu-16": {
         "owner_id": "099720109477",
         "name_pattern": "ubuntu-pro-server/images/hvm-ssd/ubuntu-xenial-16.04-amd64-pro-server*",


### PR DESCRIPTION
Ticket: none
