### PR TITLE
Removed unneeded global statements

### DIFF
--- a/cf_remote/log.py
+++ b/cf_remote/log.py
@@ -12,7 +12,6 @@ def set_level(lvl):
 
 def log(msg, lvl):
     lvl = lvl.upper()
-    global level
     if levels[lvl] >= level:
         print("[{}] {}".format(lvl, msg))
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,7 +11,6 @@ def _add_x_y(x=0, y=0):
 
 
 def test_cache():
-    global _calls
     assert _calls == 0
 
     assert _add_x_y(2, 3) == 5


### PR DESCRIPTION
Since the value is never assigned to, only read from, the global
statements make no difference here.

Newer versions of flake8 complain about this.