### PR TITLE
CFE-4518: Added CFEngine ID in cf-remote info

### DIFF
--- a/cf_remote/nt-discovery.sh
+++ b/cf_remote/nt-discovery.sh
@@ -46,6 +46,11 @@ run_command "uname -m" "ARCH"
 run_command "cat /etc/os-release" "OS_RELEASE"
 run_command "cat /etc/redhat-release" "REDHAT_RELEASE"
 
+# cf-key
+
+cfkey_path=$(cf_path "cf-key")
+run_command "$cfkey_path -p" "CFENGINE_ID" "Couldn't run cf-key"
+
 # cf-agent
 
 cfagent_path=$(cf_path "cf-agent")

--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -101,6 +101,12 @@ def print_info(data):
             output["Policy server"] = policy_server
         else:
             output["Policy server"] = "None (not bootstrapped yet)"
+
+        cfengine_id = data.get("cfengine_id")
+        if cfengine_id:
+            output["CFEngine ID"] = cfengine_id
+        else:
+            output["CFEngine ID"] = "None (no key generated yet)"
     else:
         output["CFEngine"] = "Not installed"
 
@@ -249,6 +255,7 @@ def get_info(host, *, users=None, connection=None):
             data["redhat_release"] = redhat_release_data
 
         data["package_tags"] = get_package_tags(os_release_data, redhat_release_data)
+        data["cfengine_id"] = discovery.get("NTD_CFENGINE_ID")
         data["agent_location"] = discovery.get("NTD_CFAGENT_PATH")
         data["policy_server"] = discovery.get("NTD_POLICY_SERVER")
         agent = r"/var/cfengine/bin/cf-agent"


### PR DESCRIPTION
cf-remote info before change:

```bash
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (master)$ python3 cf_remote info -H hubbefore

ubuntu@54.229.152.35
OS            : Ubuntu 20
Architecture  : x86_64
CFEngine      : 3.24.1 (Enterprise)
Policy server : None (not bootstrapped yet)
Binaries      : dpkg, apt
```

cf-remote info after change:

```bash
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (cfengine_id)$ python3 cf_remote info -H hubbefore

ubuntu@54.229.152.35
OS            : Ubuntu 20
Architecture  : x86_64
CFEngine      : 3.24.1 (Enterprise)
Policy server : None (not bootstrapped yet)
CFEngine ID   : SHA=478526c182bceec13f27c45aa6be6ac0bad9255c2d2a589f80fd5a9a872d4e0e
Binaries      : dpkg, apt
```