### PR TITLE
CFE-3919: Added role in cf-remote info

### DIFF
--- a/cf_remote/nt-discovery.sh
+++ b/cf_remote/nt-discovery.sh
@@ -21,6 +21,19 @@ run_command() {
   fi	
 }
 
+cf_path() {
+  # $1: cf program
+  ppath=$(command -v $1)
+
+  if [ -z "$ppath" ]; then
+    ppath=$(command -v /var/cfengine/bin/$1)
+  else
+    # $1 is installed somewhere else and is not in $PATH
+    ppath="$1"
+  fi
+  echo "$ppath"
+}
+
 run_command "uname" "UNAME"
 run_command "uname -m" "ARCH"
 run_command "cat /etc/os-release" "OS_RELEASE"
@@ -28,15 +41,7 @@ run_command "cat /etc/redhat-release" "REDHAT_RELEASE"
 
 # cf-agent
 
-cfagent_path=$(command -v cf-agent)
-
-if ! [ $? -eq "0" ]; then
-  cfagent_path=$(command -v /var/cfengine/bin/cf-agent)
-
-  if   ! [ $? -eq "0" ]; then
-    cfagent_path="cf-agent"
-  fi
-fi
+cfagent_path=$(echo $cf_path "cf-agent")
 
 run_command "command -v $cfagent_path" "CFAGENT_PATH" "Cannot find cf-agent"
 run_command "$cfagent_path --version" "CFAGENT_VERSION" 

--- a/cf_remote/nt-discovery.sh
+++ b/cf_remote/nt-discovery.sh
@@ -22,16 +22,23 @@ run_command() {
 }
 
 cf_path() {
-  # $1: cf program
+  # $1 = path to cf program
+  # we check if path exists with command -v to locate executables associated with a command
   ppath=$(command -v $1)
 
-  if [ -z "$ppath" ]; then
-    ppath=$(command -v /var/cfengine/bin/$1)
-  else
-    # $1 is installed somewhere else and is not in $PATH
-    ppath="$1"
+  if [ -n "$ppath" ]; then
+    echo "$1"
+    return 0;
   fi
-  echo "$ppath"
+  # $1 is installed somewhere else and is not in $PATH
+  ppath=$(command -v /var/cfengine/bin/$1)
+  
+  if [ -n "$ppath" ]; then
+    echo "/var/cfengine/bin/$1"
+    return 0;
+  fi
+  # couldn't locate $1, function fails
+  return 1;
 }
 
 run_command "uname" "UNAME"
@@ -41,11 +48,16 @@ run_command "cat /etc/redhat-release" "REDHAT_RELEASE"
 
 # cf-agent
 
-cfagent_path=$(echo $cf_path "cf-agent")
+cfagent_path=$(cf_path "cf-agent")
 
 run_command "command -v $cfagent_path" "CFAGENT_PATH" "Cannot find cf-agent"
 run_command "$cfagent_path --version" "CFAGENT_VERSION" 
 run_command "cat /var/cfengine/policy_server.dat" "POLICY_SERVER"
+
+# cf-hub
+
+cfhub_path=$(cf_path "cf-hub")
+run_command "$cfhub_path --version" "CFHUB" "Cannot find cf-hub"
 
 # packages
 

--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -91,9 +91,10 @@ def print_info(data):
     if "arch" in data:
         output["Architecture"] = data["arch"]
 
-    agent_version = data["agent_version"]
-    if agent_version:
-        output["CFEngine"] = agent_version
+    role = data["role"]
+    if data["agent_version"]:
+        version, edition = data["agent_version"].split()
+        output["CFEngine"] = "{} ({} {})".format(version, edition.strip("()"), role)
 
         policy_server = data.get("policy_server")
         if policy_server:
@@ -253,6 +254,7 @@ def get_info(host, *, users=None, connection=None):
         agent = r"/var/cfengine/bin/cf-agent"
         data["agent"] = agent
         data["agent_version"] = parse_version(discovery.get("NTD_CFAGENT_VERSION"))
+        data["role"] = "hub" if discovery.get("NTD_CFHUB") else "client"
 
         data["bin"] = {}
         for bin in ["dpkg", "rpm", "yum", "apt", "pkg", "zypper"]:


### PR DESCRIPTION
Hub before change:

```bash
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (master)$ python3 cf_remote info -H hubbefore

ubuntu@54.229.152.35
OS            : Ubuntu 20
Architecture  : x86_64
CFEngine      : 3.24.1 (Enterprise)
Policy server : None (not bootstrapped yet)
Binaries      : dpkg, apt
```

Hub after change:

```bash
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (role-info)$ python3 cf_remote info -H hubbefore

ubuntu@54.229.152.35
OS            : Ubuntu 20
Architecture  : x86_64
CFEngine      : 3.24.1 (Enterprise hub)
Policy server : None (not bootstrapped yet)
Binaries      : dpkg, apt
```

Client before change:

```bash
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (master)$ python3 cf_remote info -H clientbefore

ubuntu@52.31.25.14
OS            : Ubuntu 20
Architecture  : x86_64
CFEngine      : 3.24.1 (Enterprise)
Policy server : None (not bootstrapped yet)
Binaries      : dpkg, apt

```

Client after change:

```bash
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (role-info)$ python3 cf_remote info -H clientbefore

ubuntu@52.31.25.14
OS            : Ubuntu 20
Architecture  : x86_64
CFEngine      : 3.24.1 (Enterprise client)
Policy server : None (not bootstrapped yet)
Binaries      : dpkg, apt

```