### PR TITLE
ENT-12764 Fixed unhandled invalid checksum error when downloading packages

### DIFF
--- a/cf_remote/aramid.py
+++ b/cf_remote/aramid.py
@@ -250,11 +250,18 @@ def _wait_for_tasks(hosts, tasks, ignore_failed, echo, echo_action, out_flag="")
 
             if task.proc.args[0] == "scp":
                 log.debug(
-                    f"Copying '{task.action}' to {task.host.user}@{task.host.host_name} over scp"
+                    "Copying '{}' to {}@{} over scp".format(
+                        task.action, task.host.user, task.host.host_name
+                    )
                 )
             else:
                 log.debug(
-                    f"Running '{task.action}' on {task.host.user}@{task.host.host_name} over {task.proc.args[0]}"
+                    "Running '{}' on {}@{} over {}".format(
+                        task.action,
+                        task.host.user,
+                        task.host.host_name,
+                        task.proc.args[0],
+                    )
                 )
 
             try:

--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -14,6 +14,7 @@ from cf_remote.utils import (
     user_error,
     parse_systeminfo,
     parse_version,
+    ChecksumError,
 )
 from cf_remote.ssh import ssh_sudo, ssh_cmd, scp, auto_connect
 from cf_remote import log
@@ -515,16 +516,20 @@ def install_host(
         package = packages[0]
 
     if not package:
-        package = get_package_from_host_info(
-            data.get("package_tags"),
-            data.get("bin"),
-            data.get("arch"),
-            version,
-            hub,
-            edition,
-            packages,
-            remote_download,
-        )
+        try:
+            package = get_package_from_host_info(
+                data.get("package_tags"),
+                data.get("bin"),
+                data.get("arch"),
+                version,
+                hub,
+                edition,
+                packages,
+                remote_download,
+            )
+        except ChecksumError as ce:
+            log.error(ce)
+            return 1
 
     if not package:
         log.error("Installation failed - no package found!")

--- a/cf_remote/utils.py
+++ b/cf_remote/utils.py
@@ -279,3 +279,7 @@ def has_unescaped_character(string, char):
 
 def programmer_error(msg):
     sys.exit("Programmer error: " + msg)
+
+
+class ChecksumError(Exception):
+    pass

--- a/cf_remote/web.py
+++ b/cf_remote/web.py
@@ -1,4 +1,3 @@
-import hashlib
 import os
 import fcntl
 import re

--- a/cf_remote/web.py
+++ b/cf_remote/web.py
@@ -13,6 +13,7 @@ from cf_remote.utils import (
 )
 from cf_remote import log
 from cf_remote.paths import cf_remote_dir, cf_remote_packages_dir
+from cf_remote.utils import ChecksumError
 
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
@@ -34,7 +35,7 @@ def get_json(url):
 def download_package(url, path=None, checksum=None):
 
     if checksum and not SHA256_RE.match(checksum):
-        user_error(
+        raise ChecksumError(
             "Invalid checksum or unsupported checksum algorithm: '%s'" % checksum
         )
 
@@ -57,7 +58,7 @@ def download_package(url, path=None, checksum=None):
             f.seek(0)
             content = f.read()
             if checksum and is_different_checksum(checksum, content):
-                user_error(
+                raise ChecksumError(
                     "Downloaded file '{}' does not match expected checksum '{}'. Please delete the file.".format(
                         filename, checksum
                     )
@@ -68,7 +69,7 @@ def download_package(url, path=None, checksum=None):
 
             answer = urllib.request.urlopen(url).read()
             if checksum and is_different_checksum(checksum, answer):
-                user_error(
+                raise ChecksumError(
                     "Downloaded file '{}' does not match expected checksum '{}'. Please delete the file.".format(
                         filename, checksum
                     )


### PR DESCRIPTION
In the ticket mentioned in this commit, cf-remote seem to never copy downloaded files to the remote host for version 3.21.4. It is actually hanging indefinitely after seeing that the checksum of the artifact doesn't match the checksum of the downloaded package. This is because under the hood, `download_package` calls `sys.exit` if the checksum doesn't match. However, using `sys.exit` inside of a pooled process causes undefined behavior. The pool hangs indefinitely, waiting for the thread to return.

Previous output:

```
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (master)$ python3 cf_remote --version 3.21.4  install --hub debz --bootstrap debz

admin@63.35.228.231
OS            : Debian 12
Architecture  : x86_64
CFEngine      : 3.21.4 (Enterprise hub)
Policy server : 172.31.38.223
CFEngine ID   : SHA=71e1dfd8ea0f275eebb822a268479e4bb7100736ecc25ca37d4e3ab404d12f1c
Private IP    : 172.31.38.223 
Binaries      : dpkg, apt, curl

Package '/home/victor-moene/.cfengine/cf-remote/packages/cfengine-nova-hub_3.21.4-1.debian12_amd64.deb' already downloaded
> Nothing is happening
```

New output:
```
(.venv) victor-moene@victomoe:~/northern.tech/cf-remote (checksumerror)$ python3 cf_remote --version 3.21.4  install --hub debz --bootstrap deb

admin@63.35.228.231
OS            : Debian 12
Architecture  : x86_64
CFEngine      : 3.21.4 (Enterprise hub)
Policy server : 172.31.38.223
CFEngine ID   : SHA=71e1dfd8ea0f275eebb822a268479e4bb7100736ecc25ca37d4e3ab404d12f1c
Private IP    : 172.31.38.223 
Binaries      : dpkg, apt, curl

Package '/home/victor-moene/.cfengine/cf-remote/packages/cfengine-nova-hub_3.21.4-1.debian12_amd64.deb' already downloaded
cf_remote: Downloaded file 'cfengine-nova-hub_3.21.4-1.debian12_amd64.deb' does not match expected checksum 'dcb2ad40771f1d2003fd406a6ca5a4aa473a3813b145d84fe36f9005d31f2e8c'. Please delete the file.
```

