### PR TITLE
Set default spawn count to 1

### DIFF
--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -219,7 +219,7 @@ def _get_arg_parser():
         action="store_true",
     )
     sp.add_argument("--platform", help="Platform to use", type=str)
-    sp.add_argument("--count", help="How many hosts to spawn", type=int)
+    sp.add_argument("--count", default=1, help="How many hosts to spawn", type=int)
     sp.add_argument(
         "--role", help="Role of the hosts", choices=["hub", "hubs", "client", "clients"]
     )


### PR DESCRIPTION
Most often I want to just spawn a single VM. Hence, I'd rather have the
`--count` argument default to `1` instead of having to specify it each
time.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
