### PR TITLE
CFE-4576: Fixed blocking ssh connection for newer nova packages

### DIFF
--- a/cf_remote/remote.py
+++ b/cf_remote/remote.py
@@ -287,7 +287,7 @@ def install_package(host, pkg, data, *, connection=None):
     print("Installing: '{}' on '{}'".format(pkg, host))
     output = None
     if ".deb" in pkg:
-        output = ssh_sudo(connection, 'dpkg -i "{}"'.format(pkg), True)
+        output = ssh_sudo(connection, 'dpkg -i "{}"'.format(pkg), True, needs_pty=True)
     elif ".msi" in pkg:
         # Windows is crazy, be careful if you decide to change this;
         # This needs to work in both powershell and cmd, and in
@@ -297,7 +297,9 @@ def install_package(host, pkg, data, *, connection=None):
         output = ssh_cmd(connection, powershell(r".\{} ; sleep 10".format(pkg)), True)
     elif ".rpm" in pkg:
         if "yum" in data["bin"]:
-            output = ssh_sudo(connection, "yum -y install {}".format(pkg), True)
+            output = ssh_sudo(
+                connection, "yum -y install {}".format(pkg), True, needs_pty=True
+            )
         elif "zypper" in data["bin"]:  # suse case
             allow_unsigned = (
                 ""
@@ -306,7 +308,10 @@ def install_package(host, pkg, data, *, connection=None):
                 else "--allow-unsigned-rpm"
             )
             output = ssh_sudo(
-                connection, "zypper install -y {} {}".format(allow_unsigned, pkg), True
+                connection,
+                "zypper install -y {} {}".format(allow_unsigned, pkg),
+                True,
+                needs_pty=True,
             )
         else:
             log.error(


### PR DESCRIPTION

When piping the output of the installation command (for example `sudo dpkg -i package.deb`) for newer nova hub packages, cf_remote hangs. Cfengine gets correctly installed but when cf-remote waits for its output, it never finishes. My theory is that the is something wrong with how the scripts in the package interact with stdin, stdout or the terminal, when run in non-interactive mode. I managed to fix this issue by running the installation command inside its own pty (pseudo terminal interface). 

The way I made it work is by wrapping the installation command inside `script`, which creates a pty for the process. `script -qec "command" /dev/null`. This allows cf-remote to directly pipe from the script command and it works. I don't know if this is a perfect fix, I don't know if we want to modify the buildscripts to make it less interactive.