### PR TITLE
CFE-4580: Fixed bad assertion after reading cloud state

### DIFF
--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -476,7 +476,7 @@ def is_in_cloud_state(name):
         return False
     # else
     state = read_json(paths.CLOUD_STATE_FPATH)
-    assert state, "Failed reading from '{}'".format(paths.CLOUD_STATE_FPATH)
+    assert state is not None, "Failed reading from '{}'".format(paths.CLOUD_STATE_FPATH)
     if name in state:
         return True
     if ("@" + name) in state:


### PR DESCRIPTION
An assert was triggered if the clould state was empty (i.e., `{}`). This
is because an empty object evaluated to `False`. Instead we should check
that it is not `None`, meaning it failed to read it.

Ticket: CFE-4580
Changelog: Title
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
