### PR TITLE
Fix AWS AMI lookup matching wrong Ubuntu version

### DIFF
--- a/cf_remote/cloud_data.py
+++ b/cf_remote/cloud_data.py
@@ -40,12 +40,12 @@ aws_image_criteria = {
     },
     "ubuntu-24": {
         "owner_id": "099720109477",
-        "name_pattern": "ubuntu/images/hvm-ssd-gp3/ubuntu-*-{version}*",
+        "name_pattern": "ubuntu/images/hvm-ssd-gp3/ubuntu-*-{version}.*",
         "user": "ubuntu",
     },
     "ubuntu": {
         "owner_id": "099720109477",
-        "name_pattern": "ubuntu/images/hvm-ssd/ubuntu-*-{version}*",
+        "name_pattern": "ubuntu/images/hvm-ssd/ubuntu-*-{version}.*",
         "user": "ubuntu",
     },
     "centos": {


### PR DESCRIPTION
The generic `ubuntu` AMI `name_pattern` formatted to `ubuntu-*-20*`, which also matched newer releases via their `20XX` build-date suffix (e.g. `ubuntu-jammy-22.04-...-20231201`). `_get_ami()` picks the newest by creation date, so `--platform ubuntu-20` was spawning Ubuntu 22.

Anchor the version on the dot (`{version}.*`) so `ubuntu-20` only matches `ubuntu-*-20.04-*`, etc. Same fix applied to the `ubuntu-24` entry for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)