### PR TITLE
CFE-4661: Fixed an issue where wrong names in --clients would cause cf-remote to hang

### DIFF
--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -1,6 +1,8 @@
 import argparse
 import os
 import sys
+import re
+import socket
 
 from cf_remote import log
 from cf_remote import version
@@ -613,6 +615,13 @@ def get_cloud_hosts(name, bootstrap_ips=False):
     return ret
 
 
+def dns_lookup(name):
+    try:
+        return bool(socket.getaddrinfo(name, 22))
+    except socket.gaierror as e:
+        raise CFRUserError("DNS lookup failed for '{}': {}".format(name, e))
+
+
 def resolve_hosts(string, single=False, bootstrap_ips=False):
     log.debug("resolving hosts from '{}'".format(string))
     if is_file_string(string):
@@ -627,8 +636,12 @@ def resolve_hosts(string, single=False, bootstrap_ips=False):
             hosts = get_cloud_hosts(name, bootstrap_ips)
             ret.extend(hosts)
             log.debug("found in cloud, adding '{}'".format(hosts))
-        else:
+        elif name.startswith("@"):
+            raise CFRUserError("'{}' does not exist.".format(name))
+        elif re.search(r"[@:.]", name) or dns_lookup(name):
             ret.append(name)
+        else:
+            raise CFRUserError("'{}' does not exist.".format(name))
 
     if single:
         if len(ret) != 1:

--- a/cf_remote/main.py
+++ b/cf_remote/main.py
@@ -504,7 +504,7 @@ def validate_command(command, args):
     if command in ["sudo", "run"]:
         if len(args.remote_command) != 1:
             raise CFRExitError(
-                "cf-remote sude/run requires exactly 1 command (use quotes)"
+                "cf-remote sudo/run requires exactly 1 command (use quotes)"
             )
         args.remote_command = args.remote_command[0]
 


### PR DESCRIPTION
Tested output before and after changes with existing group, non-existing group, (both with and without @ before group name) and localhost.

### Existing group:

**Command and output before changes:**
```
% cf-remote install --clients client

ubuntu@3.251.240.175
OS            : Ubuntu 24
Architecture  : x86_64
CFEngine      : 3.27.1 (Enterprise client)
Policy server : None (not bootstrapped yet)
.....
```
With preceding `@`:
```
% cf-remote install --clients @client

ubuntu@3.251.240.175
OS            : Ubuntu 24
Architecture  : x86_64
CFEngine      : 3.27.1 (Enterprise client)
Policy server : None (not bootstrapped yet)
....
```

**Command and output after changes:**
```
% cf-remote install --clients client

ubuntu@3.251.240.175
OS            : Ubuntu 24
Architecture  : x86_64
CFEngine      : 3.27.1 (Enterprise client)
Policy server : None (not bootstrapped yet)
.......
```

With preceding `@`:
```
% cf-remote install --clients @client

ubuntu@3.251.240.175
OS            : Ubuntu 24
Architecture  : x86_64
CFEngine      : 3.27.1 (Enterprise client)
Policy server : None (not bootstrapped yet)
......
```

### Non-existing group:

**Command and output before changes:**
```
% cf-remote install --clients test
```

With preceding `@`:
```
% cf-remote install --clients @test  

```
The command gives no output, and the program hangs for an indefinite time period.


**Command and output after changes:**
```
% cf-remote install --clients test

Error: 'test' does not exist.
``` 

With preceding `@`:
```
% cf-remote install --clients @test

Error: '@test' does not exist.
```

### `localhost`:

**Command and output before changes:**
```
% cf-remote install --clients localhost 
Password:
``` 

**Command and output after changes:**
```
% cf-remote install --clients localhost
Password:
```